### PR TITLE
Support running multiple subscribers and liveliness tokens

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3148,6 +3148,7 @@ dependencies = [
  "clap",
  "futures",
  "mcap",
+ "once_cell",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,3 +39,4 @@ zenoh-plugin-rest = { version = "1.6.2", default-features = false, features = [
 zenoh-ext = { version = "1.6.2", default-features = false, features = [
   "unstable",
 ] }
+once_cell = "1.21.3"

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -217,6 +217,5 @@ pub(crate) fn zenoh_qos_to_string(zenoh_qos: &str) -> Result<String> {
 static GLOBAL_COUNTER: Lazy<AtomicU32> = Lazy::new(|| AtomicU32::new(1));
 /// Get a new entity ID by increasing the number
 pub(crate) fn get_entity_id() -> u32 {
-    let previous_value = GLOBAL_COUNTER.fetch_add(1, Ordering::SeqCst);
-    previous_value
+    GLOBAL_COUNTER.fetch_add(1, Ordering::SeqCst)
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -10,6 +10,9 @@
 // Contributors:
 //   ChenYing Kuo, <cy@zettascale.tech>
 //
+use once_cell::sync::Lazy;
+use std::sync::atomic::{AtomicU32, Ordering};
+
 use anyhow::{Result, anyhow};
 use chrono::Duration;
 use serde::{Deserialize, Serialize};
@@ -209,4 +212,11 @@ fn parse_zenoh_qos(zenoh_qos: &str) -> Result<QoSProfile> {
 /// Transform Zenoh QoS into a string
 pub(crate) fn zenoh_qos_to_string(zenoh_qos: &str) -> Result<String> {
     Ok(serde_yaml::to_string(&vec![parse_zenoh_qos(zenoh_qos)?])?)
+}
+
+static GLOBAL_COUNTER: Lazy<AtomicU32> = Lazy::new(|| AtomicU32::new(1));
+/// Get a new entity ID by increasing the number
+pub(crate) fn get_entity_id() -> u32 {
+    let previous_value = GLOBAL_COUNTER.fetch_add(1, Ordering::SeqCst);
+    previous_value
 }


### PR DESCRIPTION
The MCAP writer will subscribe to liveliness tokens and check if the topic is what we want.
If yes, create a corresponding subscriber and declare a liveliness token.
That said, we will have a specific subscriber for every topic, which can reduce the congestion issue.
A liveliness token can make the subscriber visible, and it can trigger the matched event on the publisher side to start to publish data (If there is no other subscriber)